### PR TITLE
Fixed the bug that the wechat qr-code can't work.

### DIFF
--- a/needsharebutton.js
+++ b/needsharebutton.js
@@ -109,7 +109,7 @@
       },
       "wechat": function (el) {
         var myoptions = getOptions(el);
-        var imgSrc = "https://api.qinco.me/api/qr?size=400&content=" + encodeURIComponent(myoptions.url);
+        var imgSrc = "https://pan.baidu.com/share/qrcode?w=400&h=400&url=" + encodeURIComponent(myoptions.url);
         var dropdownEl = el.querySelector(".need-share-button_dropdown");
         var img = dropdownEl.getElementsByClassName("need-share-wechat-code-image")[0];
         if (img) {


### PR DESCRIPTION
The api link "https://api.qinco.me/api/qr?size=400&content=" is disabled，and I changed it to "https://pan.baidu.com/share/qrcode?w=400&h=400&url=", which is from BaiDu.